### PR TITLE
bug fix getCurrentThemeName

### DIFF
--- a/pixel_cloudflare_turnstile.php
+++ b/pixel_cloudflare_turnstile.php
@@ -562,10 +562,7 @@ class Pixel_cloudflare_turnstile extends Module implements WidgetInterface
      */
     public function getCurrentThemeName(): string
     {
-        /** @var ThemeProviderInterface $themeProvider */
-        $themeProvider = $this->get('prestashop.core.addon.theme.theme_provider');
-
-        return $themeProvider ? $themeProvider->getCurrentlyUsedTheme()->getName() : '{themeName}';
+        return rtrim(Context::getContext()->shop->theme->getDirectory(), '/');
     }
 
     /**


### PR DESCRIPTION
Context::getContext()->shop->theme->getDirectory() used instead of service works in 1.7.7

BTW service prestashop.core.addon.theme.theme_provider should not be available in PrestaShop 8 open source.